### PR TITLE
chore: bump root pnpm to 11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "rolldown-starter",
   "license": "MIT",
   "type": "module",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "build": "RD_LOG=error rolldown -c ./rolldown.config.mjs"
   },


### PR DESCRIPTION
## Summary
- add the missing root `packageManager` field with `pnpm@11.1.2`
- keep the change scoped to the top-level `package.json` only
- avoid lockfile, workflow, docs, and nested package changes

## Testing
- not run (root packageManager metadata change only)